### PR TITLE
Publish products with release

### DIFF
--- a/.github/workflows/product.yml
+++ b/.github/workflows/product.yml
@@ -14,11 +14,11 @@ jobs:
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v3
-    - name: Set Up JDK 11
+    - name: Set Up JDK 17
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: '11'
+        java-version: '17'
     - name: Build with Maven Tycho
       run: mvn -B -U clean package
     - name: Upload Linux Artifact

--- a/.github/workflows/product.yml
+++ b/.github/workflows/product.yml
@@ -9,6 +9,9 @@ on:
   # manual trigger
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Release Products

--- a/.github/workflows/product.yml
+++ b/.github/workflows/product.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    name: Package Products
+    name: Release Products
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
@@ -21,18 +21,10 @@ jobs:
         java-version: '17'
     - name: Build with Maven Tycho
       run: mvn -B -U clean package
-    - name: Upload Linux Artifact
-      uses: actions/upload-artifact@v3
+    - name: Release Products
+      uses: softprops/action-gh-release@v1
       with:
-        name: org.palladiosimulator.somox.analyzer.rules.product-linux.gtk.x86_64.zip
-        path: products/org.palladiosimulator.somox.analyzer.rules.product/target/products/org.palladiosimulator.somox.analyzer.rules.product-linux.gtk.x86_64.zip
-    - name: Upload macOS Artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: org.palladiosimulator.somox.analyzer.rules.product-macosx.cocoa.x86_64.zip
-        path: products/org.palladiosimulator.somox.analyzer.rules.product/target/products/org.palladiosimulator.somox.analyzer.rules.product-macosx.cocoa.x86_64.zip
-    - name: Upload Windows Artifact
-      uses: actions/upload-artifact@v3
-      with:
-        name: org.palladiosimulator.somox.analyzer.rules.product-win32.win32.x86_64.zip
-        path: products/org.palladiosimulator.somox.analyzer.rules.product/target/products/org.palladiosimulator.somox.analyzer.rules.product-win32.win32.x86_64.zip
+        files: |
+          products/org.palladiosimulator.somox.analyzer.rules.product/target/products/org.palladiosimulator.somox.analyzer.rules.product-linux.gtk.x86_64.zip
+          products/org.palladiosimulator.somox.analyzer.rules.product/target/products/org.palladiosimulator.somox.analyzer.rules.product-macosx.cocoa.x86_64.zip
+          products/org.palladiosimulator.somox.analyzer.rules.product/target/products/org.palladiosimulator.somox.analyzer.rules.product-win32.win32.x86_64.zip

--- a/.github/workflows/product.yml
+++ b/.github/workflows/product.yml
@@ -2,10 +2,12 @@
 name: Continuous Product Integration
 
 on:
+  # successful merge into master
   push:
-    tags:
-      - "v*.*.*" # Push events with tags, such as v1.0.0 or v22.07.05
-  workflow_dispatch: # manual trigger
+    branches:
+      - master
+  # manual trigger
+  workflow_dispatch:
 
 jobs:
   build:
@@ -21,10 +23,14 @@ jobs:
         java-version: '17'
     - name: Build with Maven Tycho
       run: mvn -B -U clean package
+    - name: Generate Release Tag
+      run: |
+        PROJECT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+        # Replace SNAPSHOT with the current date: v5.1.0-SNAPSHOT -> v5.1.0-19700101
+        RELEASE_TAG=$(echo $PROJECT_VERSION | sed "s/SNAPSHOT/$(date +%Y%m%d)/")
+        echo "release_tag=$RELEASE_TAG" >> $GITHUB_ENV 
     - name: Release Products
       uses: softprops/action-gh-release@v1
       with:
-        files: |
-          products/org.palladiosimulator.somox.analyzer.rules.product/target/products/org.palladiosimulator.somox.analyzer.rules.product-linux.gtk.x86_64.zip
-          products/org.palladiosimulator.somox.analyzer.rules.product/target/products/org.palladiosimulator.somox.analyzer.rules.product-macosx.cocoa.x86_64.zip
-          products/org.palladiosimulator.somox.analyzer.rules.product/target/products/org.palladiosimulator.somox.analyzer.rules.product-win32.win32.x86_64.zip
+        files: products/org.palladiosimulator.somox.analyzer.rules.product/target/products/*
+        tag_name: ${{ env.release_tag }}

--- a/.github/workflows/product.yml
+++ b/.github/workflows/product.yml
@@ -29,8 +29,8 @@ jobs:
     - name: Generate Release Tag
       run: |
         PROJECT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
-        # Replace SNAPSHOT with the current date: v5.1.0-SNAPSHOT -> v5.1.0-19700101
-        RELEASE_TAG=v$(echo $PROJECT_VERSION | sed "s/SNAPSHOT/$(date +%Y%m%d)/")
+        # Replace SNAPSHOT with the current date and time: v5.1.0-SNAPSHOT -> v5.1.0.197001010000
+        RELEASE_TAG=v$(echo $PROJECT_VERSION | sed "s/-SNAPSHOT/.$(date +%Y%m%d%H%M)/")
         echo "release_tag=$RELEASE_TAG" >> $GITHUB_ENV 
     - name: Release Products
       uses: softprops/action-gh-release@v1

--- a/.github/workflows/product.yml
+++ b/.github/workflows/product.yml
@@ -30,7 +30,7 @@ jobs:
       run: |
         PROJECT_VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
         # Replace SNAPSHOT with the current date: v5.1.0-SNAPSHOT -> v5.1.0-19700101
-        RELEASE_TAG=$(echo $PROJECT_VERSION | sed "s/SNAPSHOT/$(date +%Y%m%d)/")
+        RELEASE_TAG=v$(echo $PROJECT_VERSION | sed "s/SNAPSHOT/$(date +%Y%m%d)/")
         echo "release_tag=$RELEASE_TAG" >> $GITHUB_ENV 
     - name: Release Products
       uses: softprops/action-gh-release@v1

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,80 @@
+# A GitHub Action that allows to run the RuleEngine on arbitrary GitHub repositories.
+
+name: 'Run RuleEngine'
+description: 'Reverse-engineers a project''s source into a Palladio Component Model'
+
+inputs:
+  source_path:
+    description: 'The location of the project to reverse-engineer'
+    required: true
+    default: '.'
+  rules:
+    description: 'The rules to reverse-engineer with, as a comma-separated list'
+    required: true
+    default: 'SPRING, MAVEN'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set Up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        distribution: 'temurin'
+        java-version: '17'
+
+    - name: Create temporary directory
+      shell: bash
+      run: |
+        TMP_DIR=$(mktemp -d)
+        echo "tmp_dir=$TMP_DIR" >> $GITHUB_ENV
+        mkdir $TMP_DIR/ruleengine_out
+
+    - name: Get action version
+      shell: bash
+      # Assuming a format like in the GitHub Actions documentation:
+      # /home/runner/work/_actions/repo-owner/name-of-action-repo/v1
+      # There, the 7th segment is the action's tag. This is bumped up
+      # to 8 since `cut` counts the empty string before the first / as well.
+      run: |
+        ACTION_VERSION=$(echo ${{ github.action_path }} | cut -d / -f 8- -)
+        echo "action_version=$ACTION_VERSION" >>  $GITHUB_ENV
+
+    - name: Download RuleEngine
+      shell: bash
+      # Downloads the RuleEngine with the same version that this action has
+      # (not necessarily the most recent one!).
+      run: |
+        curl -s https://api.github.com/repos/PalladioSimulator/Palladio-ReverseEngineering-SoMoX-RuleEngine/releases/tags/${{ env.action_version }} \
+          | grep -E 'browser_download_url' \
+          | grep linux \
+          | grep x86_64 \
+          | grep -Eo 'https://[^\"]*' \
+          | xargs wget -O "${{ env.tmp_dir }}/ruleengine.zip"
+
+    - name: Extract RuleEngine
+      shell: bash
+      working-directory: ${{ env.tmp_dir }}
+      run: unzip ruleengine.zip -d ruleengine
+
+    - name: Execute RuleEngine
+      shell: bash
+      working-directory: ${{ env.tmp_dir }}/ruleengine
+      run: ./eclipse -i "~/${{ inputs.source_path }}" -o "${{ env.tmp_dir }}/ruleengine_out" -r "${{ inputs.rules }}"
+
+    - name: Upload analysis results
+      uses: actions/upload-artifact@v3
+      with:
+        name: result
+        path: ${{ env.tmp_dir }}/ruleengine_out/**
+
+    - name: Upload Eclipse logs
+      uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: eclipse-logs
+        path: ${{ env.tmp_dir }}/ruleengine/configuration/*.log
+
+    - name: Delete temporary directory
+      if: always()
+      shell: bash
+      run: rm -rf ${{ env.tmp_dir }}

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
   rules:
     description: 'The rules to reverse-engineer with, as a comma-separated list'
     required: true
-    default: 'SPRING, MAVEN'
+    default: 'SPRING,MAVEN'
 
 runs:
   using: "composite"

--- a/products/org.palladiosimulator.somox.analyzer.rules.product/org.palladiosimulator.somox.analyzer.rules.main.product
+++ b/products/org.palladiosimulator.somox.analyzer.rules.product/org.palladiosimulator.somox.analyzer.rules.main.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 
-<product name="SoMoX Rule CLI" uid="org.palladiosimulator.somox.analyzer.rules.product" application="org.palladiosimulator.somox.analyzer.rules.main.application" version="5.1.0.qualifier" useFeatures="false" includeLaunchers="true">
+<product name="SoMoX Rule CLI" uid="org.palladiosimulator.somox.analyzer.rules.product" application="org.palladiosimulator.somox.analyzer.rules.main.application" version="5.1.0.qualifier" useFeatures="false" includeLaunchers="true" autoIncludeRequirements="true">
 
    <configIni use="default">
    </configIni>
@@ -29,6 +29,7 @@
       <plugin id="org.apache.felix.gogo.shell"/>
       <plugin id="org.apache.felix.scr"/>
       <plugin id="org.eclipse.equinox.console"/>
+      <plugin id="org.eclipse.jdt.core"/>
       <plugin id="org.eclipse.osgi"/>
       <plugin id="org.eclipse.osgi.services"/>
       <plugin id="org.eclipse.osgi.util"/>
@@ -43,6 +44,7 @@
       <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="0" />
       <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2" />
       <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2" />
+      <plugin id="org.eclipse.jdt.core" autoStart="true" startLevel="2" />
       <property name="eclipse.noShutdown" value="false" />
       <property name="eclipse.ignoreApp" value="false" />
    </configurations>


### PR DESCRIPTION
Creates releases on successful PRs. These releases include command-line binaries for macOS, Windows and Linux. They are also usable via an included GitHub Action, that can be accessed by `PalladioSimulator/Palladio-ReverseEngineering-SoMoX-RuleEngine@v5.1.0.202303311346`. That action then specifically executes the RuleEngine with the same version.