### PR TITLE
Remove EMFTextDiscoverer from config

### DIFF
--- a/bundles/org.palladiosimulator.somox.analyzer.rules.main/plugin.xml
+++ b/bundles/org.palladiosimulator.somox.analyzer.rules.main/plugin.xml
@@ -81,14 +81,6 @@
     </discoverer>
  </extension>
  <extension
-       id="org.palladiosimulator.somox.discoverer.emftext"
-       name="EMFText Discoverer"
-       point="org.palladiosimulator.somox.discoverer">
-    <discoverer
-          class="org.palladiosimulator.somox.discoverer.EmfTextDiscoverer">
-    </discoverer>
- </extension>
- <extension
        id="org.palladiosimulator.somox.analyzer.rules.service.performance_analyst"
        name="Performance Analyst"
        point="org.palladiosimulator.somox.analyzer.rules.analyst">


### PR DESCRIPTION
This is a leftover from b73e348.
The Eclipse product is not functional without it and the GUI might crash the rule engine as well.