### PR TITLE
Merge HTTP methods

### DIFF
--- a/bundles/org.palladiosimulator.somox.analyzer.rules.engine/src/org/palladiosimulator/somox/analyzer/rules/model/HTTPMethod.java
+++ b/bundles/org.palladiosimulator.somox.analyzer.rules.engine/src/org/palladiosimulator/somox/analyzer/rules/model/HTTPMethod.java
@@ -1,0 +1,5 @@
+package org.palladiosimulator.somox.analyzer.rules.model;
+
+public enum HTTPMethod {
+    GET, POST, PUT, DELETE, PATCH
+}

--- a/tests/org.palladiosimulator.somox.analyzer.rules.test/src/org/palladiosimulator/somox/analyzer/rules/test/model/InterfaceTest.java
+++ b/tests/org.palladiosimulator.somox.analyzer.rules.test/src/org/palladiosimulator/somox/analyzer/rules/test/model/InterfaceTest.java
@@ -17,7 +17,7 @@ import org.palladiosimulator.somox.analyzer.rules.model.EntireInterface;
 import org.palladiosimulator.somox.analyzer.rules.model.JavaInterfaceName;
 import org.palladiosimulator.somox.analyzer.rules.model.JavaOperationName;
 import org.palladiosimulator.somox.analyzer.rules.model.Operation;
-import org.palladiosimulator.somox.analyzer.rules.model.PathName;
+import org.palladiosimulator.somox.analyzer.rules.model.RESTName;
 
 public class InterfaceTest {
 
@@ -60,7 +60,7 @@ public class InterfaceTest {
     @Test
     void singlePathOperation() {
         ComponentBuilder builder = new ComponentBuilder(null);
-        Operation expectedOperation = new Operation(null, new PathName("/method"));
+        Operation expectedOperation = new Operation(null, new RESTName("/method", Optional.empty()));
         builder.provisions()
             .add(expectedOperation);
 
@@ -145,14 +145,14 @@ public class InterfaceTest {
     @Test
     void entirePathInterface() {
         ComponentBuilder builder = new ComponentBuilder(null);
-        Operation firstMethod = new Operation(null, new PathName("/common_interface/first_method"));
-        Operation secondMethod = new Operation(null, new PathName("/common_interface/second_method"));
+        Operation firstMethod = new Operation(null, new RESTName("/common_interface/first_method", Optional.empty()));
+        Operation secondMethod = new Operation(null, new RESTName("/common_interface/second_method", Optional.empty()));
         builder.provisions()
             .add(firstMethod);
         builder.provisions()
             .add(secondMethod);
         Component builtComponent = builder.create(List.of(firstMethod, secondMethod));
-        EntireInterface expectedInterface = new EntireInterface(new PathName("/common_interface"));
+        EntireInterface expectedInterface = new EntireInterface(new RESTName("/common_interface", Optional.empty()));
         assertTrue(builtComponent.provisions()
             .containsPartOf(expectedInterface));
 

--- a/tests/org.palladiosimulator.somox.analyzer.rules.test/src/org/palladiosimulator/somox/analyzer/rules/test/model/PathTest.java
+++ b/tests/org.palladiosimulator.somox.analyzer.rules.test/src/org/palladiosimulator/somox/analyzer/rules/test/model/PathTest.java
@@ -3,25 +3,28 @@ package org.palladiosimulator.somox.analyzer.rules.test.model;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 import org.palladiosimulator.somox.analyzer.rules.model.EntireInterface;
+import org.palladiosimulator.somox.analyzer.rules.model.HTTPMethod;
 import org.palladiosimulator.somox.analyzer.rules.model.Operation;
-import org.palladiosimulator.somox.analyzer.rules.model.PathName;
+import org.palladiosimulator.somox.analyzer.rules.model.RESTName;
 
 public class PathTest {
 
     @Test
     void pathNamesAreReflective() {
         String path = "/some/path";
-        PathName pathName = new PathName(path);
+        RESTName pathName = new RESTName(path, Optional.empty());
         assertTrue(pathName.isPartOf(path));
     }
 
     @Test
     void pathsArePartOfTheirPrefixes() {
         String path = "/some/path";
-        PathName interfaceName = new PathName(path);
-        PathName specificName = new PathName(path + "/that/is/more/specific");
+        RESTName interfaceName = new RESTName(path, Optional.empty());
+        RESTName specificName = new RESTName(path + "/that/is/more/specific", Optional.empty());
 
         assertTrue(specificName.isPartOf(interfaceName.getName()), "specific path is not part of its prefix");
         assertFalse(interfaceName.isPartOf(specificName.getName()), "prefix is part of a longer path");
@@ -31,10 +34,23 @@ public class PathTest {
     void prefixesAreSeparatorAware() {
         // This is NOT a legal prefix of "/some/path/..."
         String somePath = "/some/pa";
-        EntireInterface entireInterface = new EntireInterface(new PathName(somePath));
-        PathName specificPathName = new PathName("/some/path/that/is/more/specific");
+        EntireInterface entireInterface = new EntireInterface(new RESTName(somePath, Optional.empty()));
+        RESTName specificPathName = new RESTName("/some/path/that/is/more/specific", Optional.empty());
         Operation operation = new Operation(null, specificPathName);
 
         assertFalse(operation.isPartOf(entireInterface), "operation is part of illegal prefix");
+    }
+
+    @Test
+    void httpMethodsAreSpecializations() {
+        String path = "/some/path";
+        RESTName generalName = new RESTName(path, Optional.empty());
+        RESTName specificName = new RESTName(path, Optional.of(HTTPMethod.GET));
+
+        Operation generalOperation = new Operation(null, generalName);
+        Operation specificOperation = new Operation(null, specificName);
+
+        assertTrue(specificOperation.isPartOf(generalOperation));
+        assertFalse(generalOperation.isPartOf(specificOperation));
     }
 }


### PR DESCRIPTION
In Spring, there is the possibility to distinguish between e.g. `GET` and `POST` requests. This can lead to two methods having the exact same path but different HTTP methods. If possible, these variants should be treated as specializations and merged into a method agnostic variant.

With the current architecture, this is only possible if there is no more specific method of which the merged path would be a parent.