### PR TITLE
Fix Bugs Discovered By Case Studies

### DIFF
--- a/bundles/org.palladiosimulator.somox.analyzer.rules.engine/src/org/palladiosimulator/somox/analyzer/rules/engine/RuleHelper.java
+++ b/bundles/org.palladiosimulator.somox.analyzer.rules.engine/src/org/palladiosimulator/somox/analyzer/rules/engine/RuleHelper.java
@@ -208,6 +208,10 @@ public class RuleHelper {
         return fields;
     }
 
+    public static List<SingleVariableDeclaration> getParameters(MethodDeclaration method) {
+        return cast(method.parameters(), SingleVariableDeclaration.class);
+    }
+
     public static boolean isMethodAnnotatedWithName(MethodDeclaration method, String... names) {
         for (String name : names) {
             if (isObjectAnnotatedWithName(method, name)) {

--- a/bundles/org.palladiosimulator.somox.analyzer.rules.engine/src/org/palladiosimulator/somox/analyzer/rules/engine/RuleHelper.java
+++ b/bundles/org.palladiosimulator.somox.analyzer.rules.engine/src/org/palladiosimulator/somox/analyzer/rules/engine/RuleHelper.java
@@ -535,6 +535,12 @@ public class RuleHelper {
             if (expression instanceof StringLiteral) {
                 return ((StringLiteral) expression).getLiteralValue();
             }
+
+            Object compiledValue = expression.resolveConstantExpressionValue();
+            if (compiledValue != null) {
+                return compiledValue.toString();
+            }
+
         }
 
         return null;

--- a/bundles/org.palladiosimulator.somox.analyzer.rules.engine/src/org/palladiosimulator/somox/analyzer/rules/model/HTTPMethod.java
+++ b/bundles/org.palladiosimulator.somox.analyzer.rules.engine/src/org/palladiosimulator/somox/analyzer/rules/model/HTTPMethod.java
@@ -1,0 +1,5 @@
+package org.palladiosimulator.somox.analyzer.rules.model;
+
+public enum HTTPMethod {
+    GET, POST, PUT, DELETE, PATCH
+}

--- a/bundles/org.palladiosimulator.somox.analyzer.rules.engine/src/org/palladiosimulator/somox/analyzer/rules/model/RESTName.java
+++ b/bundles/org.palladiosimulator.somox.analyzer.rules.engine/src/org/palladiosimulator/somox/analyzer/rules/model/RESTName.java
@@ -63,6 +63,9 @@ public class RESTName implements InterfaceName, OperationName {
             interfaces.add(toName(prefixes.pop()));
         }
 
+        // Always add root interface
+        interfaces.add(toName(List.of()));
+
         return interfaces;
     }
 

--- a/bundles/org.palladiosimulator.somox.analyzer.rules.impl/src/org/palladiosimulator/somox/analyzer/rules/impl/SpringRules.xtend
+++ b/bundles/org.palladiosimulator.somox.analyzer.rules.impl/src/org/palladiosimulator/somox/analyzer/rules/impl/SpringRules.xtend
@@ -317,6 +317,13 @@ class SpringRules extends IRule {
 
 		if (isComponent) {
 			pcmDetector.detectComponent(unit)
+
+			getConstructors(unit)
+				.stream
+				.filter[c | isMethodAnnotatedWithName(c, "Autowired")]
+				.flatMap[c | getParameters(c).stream]
+				.filter[p | !isParameterAnnotatedWith(p, "Value")]
+				.forEach[p | pcmDetector.detectRequiredInterface(unit, p)]
 		}
 
 		if (isService || isController) {

--- a/bundles/org.palladiosimulator.somox.analyzer.rules.impl/src/org/palladiosimulator/somox/analyzer/rules/impl/SpringRules.xtend
+++ b/bundles/org.palladiosimulator.somox.analyzer.rules.impl/src/org/palladiosimulator/somox/analyzer/rules/impl/SpringRules.xtend
@@ -349,11 +349,13 @@ class SpringRules extends IRule {
 				val annotated = hasMapping(m);
 				if (annotated) {
 					var requestedMapping = getMapping(m);
-					requestedMapping = substituteVariables(requestedMapping, contextVariables);
-					var methodName = ifaceName + "/" + requestedMapping;
-					methodName = replaceArgumentsWithWildcards(methodName);
-					val httpMethod = getHTTPMethod(m);
-					pcmDetector.detectCompositeProvidedOperation(unit, m.resolveBinding, new RESTName(methodName, httpMethod));
+					if (requestedMapping !== null) {
+						requestedMapping = substituteVariables(requestedMapping, contextVariables);
+						var methodName = ifaceName + "/" + requestedMapping;
+						methodName = replaceArgumentsWithWildcards(methodName);
+						val httpMethod = getHTTPMethod(m);
+						pcmDetector.detectCompositeProvidedOperation(unit, m.resolveBinding, new RESTName(methodName, httpMethod));
+					}
 				}
 			}
 		}
@@ -369,11 +371,13 @@ class SpringRules extends IRule {
 				val annotated = hasMapping(m);
 				if (annotated) {
 					var requestedMapping = getMapping(m);
-					requestedMapping = substituteVariables(requestedMapping, contextVariables);
-					var methodName = ifaceName + "/" + requestedMapping;
-					methodName = replaceArgumentsWithWildcards(methodName);
-					val httpMethod = getHTTPMethod(m);
-					pcmDetector.detectCompositeRequiredInterface(unit, new RESTName(methodName, httpMethod));
+					if (requestedMapping !== null) {
+						requestedMapping = substituteVariables(requestedMapping, contextVariables);
+						var methodName = ifaceName + "/" + requestedMapping;
+						methodName = replaceArgumentsWithWildcards(methodName);
+						val httpMethod = getHTTPMethod(m);
+						pcmDetector.detectCompositeRequiredInterface(unit, new RESTName(methodName, httpMethod));
+					}
 				}
 			}
 		}

--- a/tests/org.palladiosimulator.somox.analyzer.rules.test/src/org/palladiosimulator/somox/analyzer/rules/test/integration/PetclinicTest.java
+++ b/tests/org.palladiosimulator.somox.analyzer.rules.test/src/org/palladiosimulator/somox/analyzer/rules/test/integration/PetclinicTest.java
@@ -17,7 +17,7 @@ public class PetclinicTest extends RuleEngineTest {
         assertComponentProvidesOperation("org_springframework_samples_petclinic_visits_web_VisitResource",
                 "/visits-service", "/visits-service/pets/visits[GET]");
         assertComponentProvidesOperation("org_springframework_samples_petclinic_customers_web_PetResource",
-                "/customers-service/owners/*", "/customers-service/owners/*/pets[GET]");
+                "/customers-service/owners/*/pets", "/customers-service/owners/*/pets[GET]");
 
         assertMaxParameterCount(2, "/customers-service/owners[PUT]", "/customers-service/owners[PUT]");
         assertMaxParameterCount(1, "/api-gateway/api/gateway/owners[GET]", "/api-gateway/api/gateway/owners[GET]");

--- a/tests/org.palladiosimulator.somox.analyzer.rules.test/src/org/palladiosimulator/somox/analyzer/rules/test/model/InterfaceTest.java
+++ b/tests/org.palladiosimulator.somox.analyzer.rules.test/src/org/palladiosimulator/somox/analyzer/rules/test/model/InterfaceTest.java
@@ -17,7 +17,7 @@ import org.palladiosimulator.somox.analyzer.rules.model.EntireInterface;
 import org.palladiosimulator.somox.analyzer.rules.model.JavaInterfaceName;
 import org.palladiosimulator.somox.analyzer.rules.model.JavaOperationName;
 import org.palladiosimulator.somox.analyzer.rules.model.Operation;
-import org.palladiosimulator.somox.analyzer.rules.model.PathName;
+import org.palladiosimulator.somox.analyzer.rules.model.RESTName;
 
 public class InterfaceTest {
 
@@ -60,7 +60,7 @@ public class InterfaceTest {
     @Test
     void singlePathOperation() {
         ComponentBuilder builder = new ComponentBuilder(null);
-        Operation expectedOperation = new Operation(null, new PathName("/method"));
+        Operation expectedOperation = new Operation(null, new RESTName("/method", Optional.empty()));
         builder.provisions()
             .add(expectedOperation);
 
@@ -145,14 +145,14 @@ public class InterfaceTest {
     @Test
     void entirePathInterface() {
         ComponentBuilder builder = new ComponentBuilder(null);
-        Operation firstMethod = new Operation(null, new PathName("/common_interface/first_method"));
-        Operation secondMethod = new Operation(null, new PathName("/common_interface/second_method"));
+        Operation firstMethod = new Operation(null, new RESTName("/common_interface/first_method", Optional.empty()));
+        Operation secondMethod = new Operation(null, new RESTName("/common_interface/second_method", Optional.empty()));
         builder.provisions()
             .add(firstMethod);
         builder.provisions()
             .add(secondMethod);
         Component builtComponent = builder.create(List.of(firstMethod, secondMethod));
-        EntireInterface expectedInterface = new EntireInterface(new PathName("/common_interface"));
+        EntireInterface expectedInterface = new EntireInterface(new RESTName("/common_interface", Optional.empty()));
         assertTrue(builtComponent.provisions()
             .containsPartOf(expectedInterface));
 

--- a/tests/org.palladiosimulator.somox.analyzer.rules.test/src/org/palladiosimulator/somox/analyzer/rules/test/model/PathTest.java
+++ b/tests/org.palladiosimulator.somox.analyzer.rules.test/src/org/palladiosimulator/somox/analyzer/rules/test/model/PathTest.java
@@ -3,25 +3,28 @@ package org.palladiosimulator.somox.analyzer.rules.test.model;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Optional;
+
 import org.junit.jupiter.api.Test;
 import org.palladiosimulator.somox.analyzer.rules.model.EntireInterface;
+import org.palladiosimulator.somox.analyzer.rules.model.HTTPMethod;
 import org.palladiosimulator.somox.analyzer.rules.model.Operation;
-import org.palladiosimulator.somox.analyzer.rules.model.PathName;
+import org.palladiosimulator.somox.analyzer.rules.model.RESTName;
 
 public class PathTest {
 
     @Test
     void pathNamesAreReflective() {
         String path = "/some/path";
-        PathName pathName = new PathName(path);
+        RESTName pathName = new RESTName(path, Optional.empty());
         assertTrue(pathName.isPartOf(path));
     }
 
     @Test
     void pathsArePartOfTheirPrefixes() {
         String path = "/some/path";
-        PathName interfaceName = new PathName(path);
-        PathName specificName = new PathName(path + "/that/is/more/specific");
+        RESTName interfaceName = new RESTName(path, Optional.empty());
+        RESTName specificName = new RESTName(path + "/that/is/more/specific", Optional.empty());
 
         assertTrue(specificName.isPartOf(interfaceName.getName()), "specific path is not part of its prefix");
         assertFalse(interfaceName.isPartOf(specificName.getName()), "prefix is part of a longer path");
@@ -31,10 +34,23 @@ public class PathTest {
     void prefixesAreSeparatorAware() {
         // This is NOT a legal prefix of "/some/path/..."
         String somePath = "/some/pa";
-        EntireInterface entireInterface = new EntireInterface(new PathName(somePath));
-        PathName specificPathName = new PathName("/some/path/that/is/more/specific");
+        EntireInterface entireInterface = new EntireInterface(new RESTName(somePath, Optional.empty()));
+        RESTName specificPathName = new RESTName("/some/path/that/is/more/specific", Optional.empty());
         Operation operation = new Operation(null, specificPathName);
 
         assertFalse(operation.isPartOf(entireInterface), "operation is part of illegal prefix");
+    }
+
+    @Test
+    void httpMethodsAreSpecializations() {
+        String path = "/some/path";
+        RESTName generalName = new RESTName(path, Optional.empty());
+        RESTName specificName = new RESTName(path, Optional.of(HTTPMethod.GET));
+
+        Operation generalOperation = new Operation(null, generalName);
+        Operation specificOperation = new Operation(null, specificName);
+
+        assertTrue(specificOperation.isPartOf(generalOperation));
+        assertFalse(generalOperation.isPartOf(specificOperation));
     }
 }


### PR DESCRIPTION
Root REST interfaces were no longer supported and compile-time constants in `@GetRequest(...)` lead to crashes.